### PR TITLE
Enable testing on sudo + fix several issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
-sudo
+# Sudo on z/OS - Readme
 
-allows a system administrator to delegate authority to give certain users
+## Introduction
+Sudo is a powerful utility that enables running commands with the privileges of another user, typically root. This readme provides essential information for installing and using Sudo on z/OS, focusing on installation requirements and best practices.
+
+## Installation as Root (UID of 0)
+- Ensure that you are logged in as the root user before proceeding with the installation.
+
+## Running the setup.sh script
+- **Caution: Sudo can only be installed and configured by the root user (UID 0).**
+- Running setup.sh with root privileges allows necessary system modifications and configurations.
+
+## Using the example $INSTALL/etc/sudoers file
+- After installation, locate the example `sudoers` file at `$SUDO_HOME/etc/sudoers`.
+- This file defines sudo access and privileges for users and groups.
+- To enable and configure Sudo, copy the example `sudoers` file to `/etc/sudoers` using: `cp $INSTALL/etc/sudoers /etc/sudoers`.
+- Exercise caution when modifying the `sudoers` file to avoid security vulnerabilities.
+- Modifying the `sudoers` file requires root privileges.
+
+## Additional Resources
+- For detailed information and best practices on managing sudo access and configuration, consult the [Sudo documentation](https://www.sudo.ws/releases/stable/#1.9.13p3).

--- a/buildenv
+++ b/buildenv
@@ -10,21 +10,22 @@ export ZOPEN_MAKE_OPTS="-j$NUM_JOBS"
 export ZOPEN_CHECK_MINIMAL="yes"
 export ZOPEN_CHECK_OPTS="-i check-verbose"
 export ZOPEN_INSTALL_OPTS="install vardir=\"\$ZOPEN_INSTALL_DIR/var/lib/sudo\" sysconfdir=\"\$ZOPEN_INSTALL_DIR/etc\" rundir=\"\$ZOPEN_INSTALL_DIR/var/run/sudo\""
-#export ZOPEN_EXTRA_CONFIGURE_OPTS="--with-vardir=\"\$ZOPEN_INSTALL_DIR/var/lib/sudo\" --with-rundir=\"\$ZOPEN_INSTALL_DIR/var/run/sudo\" --with-logpath=\"\$ZOPEN_INSTALL_DIR/var/log/sudo.log\" --with-rundir=\"\$ZOPEN_INSTALL_DIR/var/run/sudo\" --with-iologdir=\"\$ZOPEN_INSTALL_DIR/var/run/sudo-io\" --with-logdir=\"\$ZOPEN_INSTALL_DIR/var/log\" --with-relaydir=\"\$ZOPEN_INSTALL_DIR/var/log/sudo_logsrvd\" --without-interfaces --with-runas-default=BPXROOT"
-#TODO: Need to work on some of the tests before enabling
-#export ZOPEN_CHECK="skip"
 export ZOPEN_COMP=CLANG # use clang
 
 zopen_check_results()
 {
-  dir="$1"
-  pfx="$2"
-  chk="$1/$2_check.log"
+# Expected success rate should be 91.19%
+chk="$1/$2_check.log"
 
-  # Echo the following information to gauge build health
-  echo "actualFailures:0"
-  echo "totalTests:1"
-  echo "expectedFailures:0"
+successes=$(grep -e ".*: OK" ${chk} | wc -l)
+failures=$(grep -e ".*: FAIL" ${chk} | wc -l)
+totalRunTests=$(($successes+$failures))
+
+cat <<ZZ
+actualFailures:$failures
+totalTests:$totalRunTests
+expectedFailures:23
+ZZ
 }
 
 zopen_append_to_env()

--- a/buildenv
+++ b/buildenv
@@ -3,11 +3,14 @@ export ZOPEN_GIT_DEPS="make"
 export ZOPEN_TARBALL_URL="https://www.sudo.ws/dist/sudo-1.9.13p3.tar.gz"
 export ZOPEN_TARBALL_DEPS="make coreutils zoslib openssl zlib"
 #TODO: add zlib, openssl
-export ZOPEN_EXTRA_CONFIGURE_OPTS="--sysconfdir=\"\$ZOPEN_INSTALL_DIR/etc\" --with-vardir=\"\$ZOPEN_INSTALL_DIR/var/lib/sudo\" --with-rundir=\"\$ZOPEN_INSTALL_DIR/var/run/sudo\" --with-logpath=\"\$ZOPEN_INSTALL_DIR/var/log/sudo.log\" --with-rundir=\"\$ZOPEN_INSTALL_DIR/var/run/sudo\" --with-iologdir=\"\$ZOPEN_INSTALL_DIR/var/run/sudo-io\" --with-logdir=\"\$ZOPEN_INSTALL_DIR/var/log\" --with-relaydir=\"\$ZOPEN_INSTALL_DIR/var/log/sudo_logsrvd\" --without-interfaces --with-runas-default=BPXROOT"
+export ZOPEN_EXTRA_CONFIGURE_OPTS="--without-interfaces --with-runas-default=BPXROOT"
 export ZOPEN_TYPE="TARBALL"
 export ZOPEN_MAKE_MINIMAL="yes"
 export ZOPEN_MAKE_OPTS="-j$NUM_JOBS"
-export ZOPEN_MAKE_CHECK_MINIMAL="yes"
+export ZOPEN_CHECK_MINIMAL="yes"
+export ZOPEN_CHECK_OPTS="-i check-verbose"
+export ZOPEN_INSTALL_OPTS="install vardir=\"\$ZOPEN_INSTALL_DIR/var/lib/sudo\" sysconfdir=\"\$ZOPEN_INSTALL_DIR/etc\" rundir=\"\$ZOPEN_INSTALL_DIR/var/run/sudo\""
+#export ZOPEN_EXTRA_CONFIGURE_OPTS="--with-vardir=\"\$ZOPEN_INSTALL_DIR/var/lib/sudo\" --with-rundir=\"\$ZOPEN_INSTALL_DIR/var/run/sudo\" --with-logpath=\"\$ZOPEN_INSTALL_DIR/var/log/sudo.log\" --with-rundir=\"\$ZOPEN_INSTALL_DIR/var/run/sudo\" --with-iologdir=\"\$ZOPEN_INSTALL_DIR/var/run/sudo-io\" --with-logdir=\"\$ZOPEN_INSTALL_DIR/var/log\" --with-relaydir=\"\$ZOPEN_INSTALL_DIR/var/log/sudo_logsrvd\" --without-interfaces --with-runas-default=BPXROOT"
 #TODO: Need to work on some of the tests before enabling
 #export ZOPEN_CHECK="skip"
 export ZOPEN_COMP=CLANG # use clang
@@ -31,7 +34,16 @@ zopen_append_to_env()
 
 zopen_append_to_setup()
 {
-  # echo commands that will run when installing via setup.sh
+cat <<EOF
+ if [ "\$(id -u)" -eq 0 ]; then
+    echo "Adding sticky bit to binaries"
+    chown 0:0 \$SUDO_HOME/*bin/*
+    chmod u+s \$SUDO_HOME/*bin/*
+    echo "An example sudoers is provided in \$SUDO_HOME/etc/sudoers"
+ else
+    echo "You must run the setup.sh script as root. Exiting"
+ fi 
+EOF
 }
 
 zopen_get_version()

--- a/patches/PR1.patch
+++ b/patches/PR1.patch
@@ -980,7 +980,7 @@ index db65986..67461fa 100644
  
  	    if ((pw = sudo_getpwnam(prev_user)) != NULL) {
 diff --git a/plugins/sudoers/testsudoers.c b/plugins/sudoers/testsudoers.c
-index 3eea349..38951dc 100644
+index 3eea349..6e6dd61 100644
 --- a/plugins/sudoers/testsudoers.c
 +++ b/plugins/sudoers/testsudoers.c
 @@ -187,6 +187,7 @@ main(int argc, char *argv[])
@@ -1001,7 +1001,7 @@ index 3eea349..38951dc 100644
  	if (!dflag)
  	    usage();
 +#ifdef __MVS__
-+	user_name = argc ? *argv++ : (char *)"ROOT";
++	user_name = argc ? *argv++ : (char *)"BPXROOT";
 +#else
  	user_name = argc ? *argv++ : (char *)"root";
 +#endif

--- a/patches/PR1.patch
+++ b/patches/PR1.patch
@@ -1,5 +1,5 @@
 diff --git a/configure b/configure
-index d406eb7..e484091 100755
+index b4453a8..0682cc0 100755
 --- a/configure
 +++ b/configure
 @@ -10183,6 +10183,10 @@ aix[4-9]*)
@@ -178,6 +178,34 @@ index ccd2fbb..c8c47e5 100644
  	PW_COPY(pw_dir, dsize);
  	PW_COPY(pw_shell, ssize);
  
+diff --git a/lib/util/regress/mktemp/mktemp_test.c b/lib/util/regress/mktemp/mktemp_test.c
+index 134f89e..28fb68f 100644
+--- a/lib/util/regress/mktemp/mktemp_test.c
++++ b/lib/util/regress/mktemp/mktemp_test.c
+@@ -156,7 +156,9 @@ main(int argc, char *argv[])
+ 	clen = strlen(cwd);
+ 	cwd[clen++] = '/';
+ 	cwd[clen] = '\0';
+-#ifdef MAP_ANON
++#ifdef __MVS__
++	p = malloc(pg * 3);
++#elif defined(MAP_ANON)
+ 	p = mmap(NULL, pg * 3, PROT_READ | PROT_WRITE, MAP_PRIVATE|MAP_ANON, -1, 0);
+ #else
+ 	i = open("/dev/zero", O_RDWR);
+@@ -164,10 +166,12 @@ main(int argc, char *argv[])
+ 		sudo_fatal("/dev/zero");
+ 	p = mmap(NULL, pg * 3, PROT_READ | PROT_WRITE, MAP_PRIVATE, i, 0);
+ #endif
++#ifndef __MVS__
+ 	if (p == MAP_FAILED)
+ 		sudo_fatal("mmap");
+ 	if (mprotect(p, pg, PROT_NONE) || mprotect(p + pg * 2, pg, PROT_NONE))
+ 		sudo_fatal("mprotect");
++#endif
+ 	p += pg;
+ 
+ 	i = MAX_TEMPLATE_LEN + 1;
 diff --git a/lib/util/ttyname_dev.c b/lib/util/ttyname_dev.c
 index 08b9777..2312854 100644
 --- a/lib/util/ttyname_dev.c
@@ -286,7 +314,7 @@ index fb3b435..5cff31a 100644
  # C preprocessor flags
  CPPFLAGS = -I$(incdir) -I$(top_builddir) @CPPFLAGS@
 diff --git a/plugins/sudoers/Makefile.in b/plugins/sudoers/Makefile.in
-index 3dcc746..a0ccb14 100644
+index 6e7c97c..d252a3d 100644
 --- a/plugins/sudoers/Makefile.in
 +++ b/plugins/sudoers/Makefile.in
 @@ -62,10 +62,10 @@ LIBEVENTLOG = $(top_builddir)/lib/eventlog/libsudo_eventlog.la
@@ -627,7 +655,7 @@ index 6b30d03..201712b 100644
  
      /* Set key and datum. */
 diff --git a/plugins/sudoers/defaults.c b/plugins/sudoers/defaults.c
-index e90be1f..3530948 100644
+index e90be1f..0a42cd4 100644
 --- a/plugins/sudoers/defaults.c
 +++ b/plugins/sudoers/defaults.c
 @@ -605,8 +605,19 @@ init_defaults(void)
@@ -640,7 +668,7 @@ index e90be1f..3530948 100644
 +  // give it a second chance. The runas default can be
 +  // configured via /etc/sudoers, but we still need a user name
 +  // here before we even start reading sudoers.
-+  char* runas_default = getpwnam(RUNAS_DEFAULT)? RUNAS_DEFAULT : "ROOT";
++  char* runas_default = getpwnam(RUNAS_DEFAULT) ? RUNAS_DEFAULT : "BPXROOT";
 +  if ((def_runas_default = strdup(runas_default)) == NULL)
 +      goto oom;
 +#else
@@ -922,8 +950,20 @@ index 77ce395..f0c6926 100644
      if (setregid(OID(rgid), OID(egid))) {
  	sudo_warn("setregid() [%d, %d] -> [%d, %d]", (int)state->rgid,
  	    (int)state->egid, (int)OID(rgid), (int)OID(egid));
+diff --git a/plugins/sudoers/sudo_printf.c b/plugins/sudoers/sudo_printf.c
+index 5f07162..eb3fe0a 100644
+--- a/plugins/sudoers/sudo_printf.c
++++ b/plugins/sudoers/sudo_printf.c
+@@ -26,6 +26,7 @@
+ #include <stdio.h>
+ #include <stdarg.h>
+ #include <errno.h>
++#include <fcntl.h>
+ 
+ #include "sudo_compat.h"
+ #include "sudo_plugin.h"
 diff --git a/plugins/sudoers/sudoers.c b/plugins/sudoers/sudoers.c
-index 9ae5f96..15547a6 100644
+index db65986..67461fa 100644
 --- a/plugins/sudoers/sudoers.c
 +++ b/plugins/sudoers/sudoers.c
 @@ -622,7 +622,11 @@ sudoers_policy_main(int argc, char * const argv[], int pwflag, char *env_add[],
@@ -1017,10 +1057,10 @@ index da93c1d..f49e517 100644
  # C preprocessor flags
  CPPFLAGS = -I$(incdir) -I$(top_builddir) @CPPFLAGS@
 diff --git a/scripts/install-sh b/scripts/install-sh
-index 228a0b1..1a2d34c 100755
+index 228a0b1..dc7eaba 100755
 --- a/scripts/install-sh
 +++ b/scripts/install-sh
-@@ -171,12 +171,13 @@ if ${DIRMODE} ; then
+@@ -171,12 +171,14 @@ if ${DIRMODE} ; then
  	if [ ! -d "${DEST}" ] ; then
  	    ${MKDIR} "${DEST}" || exit 1
  	fi
@@ -1030,17 +1070,18 @@ index 228a0b1..1a2d34c 100755
 -	if ${CHGROUPIT} ; then
 -	    ${CHGRP} "${GROUP}" "${DEST}" || exit 1
 -	fi
-+## z/OS: Don't change owner/group as we don't have root privileges at that moment.
-+#      if ${CHOWNIT} ; then
-+#          ${CHOWN} "${OWNER}" "${DEST}" || exit 1
-+#      fi
-+#      if ${CHGROUPIT} ; then
-+#          ${CHGRP} "${GROUP}" "${DEST}" || exit 1
-+#      fi
++  if [ "$(uname -s)" != "OS/390" ]; then
++    if ${CHOWNIT} ; then
++        ${CHOWN} "${OWNER}" "${DEST}" || exit 1
++    fi
++    if ${CHGROUPIT} ; then
++        ${CHGRP} "${GROUP}" "${DEST}" || exit 1
++    fi
++  fi
  	if ${CHMODIT} ; then
  	    ${CHMOD} "${MODE}"  "${DEST}" || exit 1
  	fi
-@@ -227,12 +228,13 @@ fi
+@@ -227,11 +229,13 @@ fi
  if ${STRIPIT} ; then
      ${STRIP} "${DEST}" || exit 1
  fi
@@ -1049,17 +1090,16 @@ index 228a0b1..1a2d34c 100755
 -fi
 -if ${CHGROUPIT} ; then
 -    ${CHGRP} "${GROUP}" "${DEST}" || exit 1
--fi
-+## z/OS: Don't change owner/group as we don't have root privileges at that moment.
-+#      if ${CHOWNIT} ; then
-+#          ${CHOWN} "${OWNER}" "${DEST}" || exit 1
-+#      fi
-+#      if ${CHGROUPIT} ; then
-+#          ${CHGRP} "${GROUP}" "${DEST}" || exit 1
-+#      fi
++if [ "$(uname -s)" != "OS/390" ]; then
++  if ${CHOWNIT} ; then
++      ${CHOWN} "${OWNER}" "${DEST}" || exit 1
++  fi
++  if ${CHGROUPIT} ; then
++      ${CHGRP} "${GROUP}" "${DEST}" || exit 1
++  fi
+ fi
  if ${CHMODIT} ; then
      ${CHMOD} "${MODE}" "${DEST}" || exit 1
- fi
 diff --git a/src/Makefile.in b/src/Makefile.in
 index d9fa3a6..d882b48 100644
 --- a/src/Makefile.in


### PR DESCRIPTION
* Enabled testing (confirmed it does not require root access - it runs a set of C unit/regression tests)
Test status is:
```
actualFailures:23
totalTests:261
expectedFailures:23'
VERBOSE: 'Test results: 238 tests pass out of 261 tests - 91.19% success rate'
```
* The above results depend on https://github.com/ibmruntimes/zoslib/pull/20 going in
* I have also expanded setup.sh so that it can install properly the sudo tools under root
* Changed default ROOT id to BPXROOT for z/OS (also needed for tests)
