### PR TITLE
Update readme and installation setup to be more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,14 @@
 # Sudo on z/OS - Readme
 
 ## Introduction
-Sudo is a powerful utility that enables running commands with the privileges of another user, typically root. This readme provides essential information for installing and using Sudo on z/OS, focusing on installation requirements and best practices.
+Sudo is a powerful utility that enables running commands with the privileges of another user, typically root. 
+This readme provides essential information for installing and using Sudo on z/OS, focusing on 
+installation requirements and best practices.
 
-## Installation as Root (UID of 0)
-- Ensure that you are logged in as the root user before proceeding with the installation.
+## Special Installation Instructions
+Unlike many of the z/OS Open Tools, sudo requires post-installation steps to be performed using
+elevated privileges. 
+These instructions are printed out at the end of a standard install and explain how to copy the 
+binaries to your /usr/bin and /usr/sbin directories. 
+The instructions also explain where you can read more about sudo in general.
 
-## Running the setup.sh script
-- **Caution: Sudo can only be installed and configured by the root user (UID 0).**
-- Running setup.sh with root privileges allows necessary system modifications and configurations.
-
-## Using the example $INSTALL/etc/sudoers file
-- After installation, locate the example `sudoers` file at `$SUDO_HOME/etc/sudoers`.
-- This file defines sudo access and privileges for users and groups.
-- To enable and configure Sudo, copy the example `sudoers` file to `/etc/sudoers` using: `cp $INSTALL/etc/sudoers /etc/sudoers`.
-- Exercise caution when modifying the `sudoers` file to avoid security vulnerabilities.
-- Modifying the `sudoers` file requires root privileges.
-
-## Additional Resources
-- For detailed information and best practices on managing sudo access and configuration, consult the [Sudo documentation](https://www.sudo.ws/releases/stable/#1.9.13p3).

--- a/buildenv
+++ b/buildenv
@@ -62,7 +62,7 @@ cat <<'EOF'
  echo "cd /usr/sbin"
  echo "chmod u+s \$SBIN_SUDO"
  echo "Review the \$SUDO_INSTALL_LOCAL/etc/sudoers file."
- echo "Use sudovi to create your own /etc/sudoers file."
+ echo "Use visudo to create your own /etc/sudoers file."
  echo "================================================================================"
 EOF
 }

--- a/buildenv
+++ b/buildenv
@@ -44,17 +44,26 @@ zopen_post_install()
 zopen_append_to_setup()
 {
 cat <<EOF
- if [ "\$(id -u)" -eq 0 ]; then
-    echo "Adding sticky bit to binaries"
-    chown 0:0 \$SUDO_HOME/*bin/*
-    chmod u+s \$SUDO_HOME/*bin/*
- else
-    echo "WARNING: Either run the setup.sh script as root or run the following commands with elevated privileges:"
-    echo "chown 0:0 \$SUDO_HOME/*bin/*"
-    echo "chmod u+s \$SUDO_HOME/*bin/*"
- fi 
- echo "An example sudoers is provided in \$SUDO_HOME/etc/sudoers"
- echo "An example sudo.conf is provided in \$SUDO_HOME/etc/sudo.conf"
+ echo "================================================================================"
+ echo "IMPORTANT NOTE: Installation of sudo is NOT COMPLETE.                           "
+ echo "For details on sudo, see: https://www.sudo.ws/releases/stable/#${SUDO_VERSION}  "
+ echo "To finish installing sudo, run the following commands with elevated privileges: "
+ echo "BIN_SUDO='cvtsudoers sudo sudoedit sudoreplay'"
+ echo "SBIN_SUDO='sudo_logsrvd sudo_sendlog visudo'"
+ echo "SUDO_INSTALL_LOCAL=\$SUDO_HOME"
+EOF
+cat <<'EOF'
+ echo "cd \$SUDO_INSTALL_LOCAL/bin"
+ echo "cp \$BIN_SUDO /usr/bin/"
+ echo "cd \$SUDO_INSTALL_LOCAL/sbin"
+ echo "cp \$SBIN_SUDO /usr/sbin/"
+ echo "cd /usr/bin"
+ echo "chown 0:0 \$BIN_SUDO"
+ echo "cd /usr/sbin"
+ echo "chmod u+s \$SBIN_SUDO"
+ echo "Review the \$SUDO_INSTALL_LOCAL/etc/sudoers file."
+ echo "Use sudovi to create your own /etc/sudoers file."
+ echo "================================================================================"
 EOF
 }
 


### PR DESCRIPTION
The installation process now tells people how to finish the install with elevated privileges.

Here is an example (expanded with environment variables from a specific build)

```
================================================================================

IMPORTANT NOTE: Installation of sudo is NOT COMPLETE.
For details on sudo, see: https://www.sudo.ws/releases/stable/#1.9.13p3
To finish installing sudo, run the following commands with elevated privileges:
BIN_SUDO='cvtsudoers sudo sudoedit sudoreplay'
SBIN_SUDO='sudo_logsrvd sudo_sendlog visudo'
SUDO_INSTALL_LOCAL=/home/fultonm/zopen/usr/local/zopen/sudo/sudo-1.9.13p3
cd $SUDO_INSTALL_LOCAL/bin
cp $BIN_SUDO /usr/bin/
cd $SUDO_INSTALL_LOCAL/sbin
cp $SBIN_SUDO /usr/sbin/
cd /usr/bin
chown 0:0 $BIN_SUDO
cd /usr/sbin
chmod u+s $SBIN_SUDO
Review the $SUDO_INSTALL_LOCAL/etc/sudoers file.
Use sudovi to create your own /etc/sudoers file.
================================================================================
```